### PR TITLE
Feat: add time_zone in aws_autoscaling_schedule

### DIFF
--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -153,7 +153,7 @@ resource "aws_autoscaling_schedule" "scaledown" {
   max_size               = var.max_size_scaledown
   desired_capacity       = var.scale_down_desired
   recurrence             = var.scheduler_down
-  time_zone = var.time_zone
+  time_zone              = var.time_zone
 }
 
 #Module      : AWS AUTOSCALING SCHEDULE
@@ -166,7 +166,7 @@ resource "aws_autoscaling_schedule" "scaleup" {
   min_size               = var.min_size_scaleup
   desired_capacity       = var.scale_up_desired
   recurrence             = var.scheduler_up
-  time_zone = var.time_zone
+  time_zone              = var.time_zone
 }
 
 #Module      : AWS AUTOSCALING SCHEDULE
@@ -179,7 +179,7 @@ resource "aws_autoscaling_schedule" "spot_scaledown" {
   max_size               = var.spot_max_size_scaledown
   desired_capacity       = var.spot_scale_down_desired
   recurrence             = var.scheduler_down
-  time_zone = var.time_zone
+  time_zone              = var.time_zone
 }
 
 #Module      : AWS AUTOSCALING SCHEDULE
@@ -192,5 +192,5 @@ resource "aws_autoscaling_schedule" "spot_scaleup" {
   min_size               = var.spot_min_size
   desired_capacity       = var.spot_scale_up_desired
   recurrence             = var.scheduler_up
-  time_zone = var.time_zone
+  time_zone              = var.time_zone
 }

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -153,6 +153,7 @@ resource "aws_autoscaling_schedule" "scaledown" {
   max_size               = var.max_size_scaledown
   desired_capacity       = var.scale_down_desired
   recurrence             = var.scheduler_down
+  time_zone = var.time_zone
 }
 
 #Module      : AWS AUTOSCALING SCHEDULE
@@ -165,6 +166,7 @@ resource "aws_autoscaling_schedule" "scaleup" {
   min_size               = var.min_size_scaleup
   desired_capacity       = var.scale_up_desired
   recurrence             = var.scheduler_up
+  time_zone = var.time_zone
 }
 
 #Module      : AWS AUTOSCALING SCHEDULE
@@ -177,6 +179,7 @@ resource "aws_autoscaling_schedule" "spot_scaledown" {
   max_size               = var.spot_max_size_scaledown
   desired_capacity       = var.spot_scale_down_desired
   recurrence             = var.scheduler_down
+  time_zone = var.time_zone
 }
 
 #Module      : AWS AUTOSCALING SCHEDULE
@@ -189,4 +192,5 @@ resource "aws_autoscaling_schedule" "spot_scaleup" {
   min_size               = var.spot_min_size
   desired_capacity       = var.spot_scale_up_desired
   recurrence             = var.scheduler_up
+  time_zone = var.time_zone
 }

--- a/variables.tf
+++ b/variables.tf
@@ -470,3 +470,9 @@ variable "spot_desired_capacity" {
   default     = 3
   description = "The number of Amazon EC2 instances that should be running in the group."
 }
+
+variable "time_zone" {
+  type        = string
+  default     = "UTC"
+  description = "Specifies the time zone setting. The default value is 'UTC' (Coordinated Universal Time)."
+}


### PR DESCRIPTION
## what

- Defined a Terraform variable time_zone to store the time zone setting.
- Set the default value of time_zone to "UTC" (Coordinated Universal Time).
- Added a description to clarify the purpose of the variable.

## why

- Ensures a standardized time zone setting by default, preventing inconsistencies.
- Allows flexibility for users to override the default time zone if needed.