### PR TITLE
Fix: device_name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ resource "aws_launch_template" "on_demand" {
   user_data                            = var.user_data_base64
 
   block_device_mappings {
-    device_name = "/dev/sda1"
+    device_name = var.device_name
     ebs {
       volume_size = var.volume_size
       encrypted   = var.ebs_encryption
@@ -79,7 +79,7 @@ resource "aws_launch_template" "spot" {
 
   name_prefix = format("%s%s-spot", module.labels.id, var.delimiter)
   block_device_mappings {
-    device_name = "/dev/sda1"
+    device_name = var.device_name
     ebs {
       volume_size = var.volume_size
       encrypted   = var.ebs_encryption

--- a/variables.tf
+++ b/variables.tf
@@ -476,3 +476,9 @@ variable "time_zone" {
   default     = "UTC"
   description = "Specifies the time zone setting. The default value is 'UTC' (Coordinated Universal Time)."
 }
+
+variable "device_name" {
+  type        = string
+  default     = "/dev/xvda"
+  description = "The name of the block device to be attached to the instance, typically representing the root volume."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -479,6 +479,6 @@ variable "time_zone" {
 
 variable "device_name" {
   type        = string
-  default     = "/dev/xvda"
+  default     = "/dev/sda1"
   description = "The name of the block device to be attached to the instance, typically representing the root volume."
 }


### PR DESCRIPTION
## What

- Converted the hardcoded device_name in the Terraform module into a variable.
- Set a default value of /dev/xvda for device_name.
- Fixed an issue where Terraform was creating a new EBS volume instead of using the root volume.

## Why

- Provides flexibility for users to override the device_name if needed.
- Ensures that the correct root volume is used based on the AMI configuration.
- Prevents unintended creation of additional EBS volumes, avoiding unnecessary costs and misconfigurations.
